### PR TITLE
Credentials as envvar. New 'get' command and extending GoogleFile model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## Pending: minor version
+
+- Now credentials is the last arugment expected
+  - e.g.: google-drive ls <path> <credentials-file>
+- Now credentials could be a envvar
+  - export CREDENTIALS=credentials.json && google-drive ls <path> <credentials-file>
+- New command `get`. This will retrieve us file's metadata.
+  - e.g.: google-drive get <ID>
+- Extending models.GoogleFile.
+  - Adding: mimeType and exportLinks fields.
+  - Adding export types constants to get export type from a GoogleFile
+
 ## 0.1.3
 
 - fixing cli usecases

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 
 ## Functionalities
 
+- [X] Implement `get` to get file metadata
 - [ ] Extending `ls` for an ID file.
 - [ ] Extending `mkdir` for a path folder.
 - [ ] Implement `analysis` to extract data from the google drive.

--- a/googledrive/cli.py
+++ b/googledrive/cli.py
@@ -18,7 +18,7 @@ class Config:
     ]
 
 @click.command()
-@click.argument('credentials', type=click.Path(exists=True))
+@click.argument('credentials', envvar='CREDENTIALS', type=click.Path(exists=True))
 def login(credentials):
     """Perform a login with google oauth"""
     GoogleAuth().authenticate(
@@ -26,18 +26,36 @@ def login(credentials):
         scopes=Config.SCOPES)
 
 @click.command()
-@click.argument('credentials', type=click.Path(exists=True))
 @click.argument('path')
+@click.argument('credentials', envvar='CREDENTIALS', type=click.Path(exists=True))
 def ls(credentials, path):
     """List directory contents"""
     google_drive = GoogleDrive(credentials, Config.SCOPES)
     files = google_drive.googledrive_ls(path)
     for file in files:
-        print(file.name)  # TODO: nice print
+        print(f'- {file}')  # TODO: nice print
 
 @click.command()
-@click.argument('credentials', type=click.Path(exists=True))
+@click.argument('id')
+@click.argument('credentials', envvar='CREDENTIALS', type=click.Path(exists=True))
+def get(id, credentials):
+    """Get file metadata"""
+    google_drive = GoogleDrive(credentials, Config.SCOPES)
+    google_file = google_drive.get_file_from_id(id)
+
+    print('\nFile Metadata:\n==')
+    print(f'id: {google_file.id}')
+    print(f'name: {google_file.name}')
+    print(f'parents: {google_file.parents}')
+    print(f'mime_type: {google_file.mime_type}')
+    print(f'export_links:')
+
+    for link_type, link in google_file.export_links.items():
+        print(f'  - {link_type}: {link}')
+
+@click.command()
 @click.argument('name')
+@click.argument('credentials', envvar='CREDENTIALS', type=click.Path(exists=True))
 def mkdir(credentials, name):
     """Make directory"""
     google_drive = GoogleDrive(credentials, Config.SCOPES)
@@ -50,4 +68,5 @@ def googledrive():
 
 googledrive.add_command(login)
 googledrive.add_command(ls)
+googledrive.add_command(get)
 googledrive.add_command(mkdir)

--- a/googledrive/mappers.py
+++ b/googledrive/mappers.py
@@ -6,8 +6,16 @@ class GoogleFileDictToGoogleFile:
         if google_file_dict is None:
             return None
 
+        name = google_file_dict.get('name') or ''
+        id = google_file_dict.get('id') or ''
+        parents = google_file_dict.get('parents') or []
+        mime_type = google_file_dict.get('mimeType') or ''
+        export_links = google_file_dict.get('exportLinks') or {}
+
         return GoogleFile(
-            name=google_file_dict.get('name'),
-            id=google_file_dict.get('id'),
-            parents=google_file_dict.get('parents'),
+            name=name,
+            id=id,
+            parents=parents,
+            mime_type=mime_type,
+            export_links=export_links
         )

--- a/googledrive/models.py
+++ b/googledrive/models.py
@@ -1,12 +1,39 @@
+import json
 from dataclasses import dataclass
+
+from googleapiclient.errors import HttpError
 
 @dataclass
 class GoogleFile:
 
-    def __init__(self, name, id, parents):
-        self.name = name
+    EXPORT_TYPE_RTF                  = 'application/rtf'
+    EXPORT_TYPE_VND_OASIS            = 'application/vnd.oasis.opendocument.text'
+    EXPORT_TYPE_HTML                 = 'text/html'
+    EXPORT_TYPE_PDF                  = 'application/pdf'
+    EXPORT_TYPE_EPUB_ZIP             = 'application/epub+zip'
+    EXPORT_TYPE_ZIP                  = 'application/zip'
+    EXPORT_TYPE_VND_WORDPROCESSINGML = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    EXPORT_TYPE_PLAIN                = 'text/plain'
+
+    def __init__(
+            self,
+            name,
+            id,
+            parents,
+            mime_type,
+            export_links):
         self.id = id
+        self.name = name
         self.parents = parents
+        self.mime_type = mime_type
+        self.export_links = export_links
+
+    def get_export_link(self, export_type):
+        export_link = self.export_links[export_type] or ''
+        return export_link
+
+    def __str__(self):
+        return f'({self.id}, {self.name}, {self.mime_type})'
 
 @dataclass
 class GoogleApiClientHttpError:
@@ -16,3 +43,15 @@ class GoogleApiClientHttpError:
         self.message = message
         self.status = status
         self.details = details
+
+class GoogleApiClientHttpErrorBuilder:
+
+    def from_http_error(self, http_error: HttpError):
+        error_reason = json.loads(e.content)
+        error = error_reason['error']
+        return GoogleApiClientHttpError(
+            error['code'],
+            error['message'],
+            error['status'],
+            error['details'] if 'details' in error else []
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -402,7 +402,7 @@ class TestFilesAPI(TestCase):
         # given:
         folder_parent = 'parent'
         filename = 'filename'
-        folder = GoogleFile(id='new_parent_id', name='folder', parents=[])
+        folder = GoogleFile(id='new_parent_id', name='folder', parents=[], mime_type='', export_links={})
 
         # when:
         self.sut.create_sheet(folder_parent, folder, filename)
@@ -453,7 +453,7 @@ class TestFilesAPI(TestCase):
         folder_name = 'my_folder'
         self.sut.set_pages_requested(1)
         self.sut.set_response_files([
-            GoogleFile(id='some id', name=folder_name, parents=[])
+            GoogleFile(id='some id', name=folder_name, parents=[], mime_type='', export_links={})
         ])
 
         # when:
@@ -490,7 +490,7 @@ class TestFilesAPI(TestCase):
         file_id = 'file_id'
         self.sut.set_googledrive_get_file_response(
             f"/{foldername}/{filename}",
-            GoogleFile(id=file_id, name=filename, parents=[]))
+            GoogleFile(id=file_id, name=filename, parents=[], mime_type='', export_links={}))
         rows_range = 'A2::F4'
 
         # when:

--- a/tests/test_mappers.py
+++ b/tests/test_mappers.py
@@ -13,7 +13,12 @@ class TestGoogleFileDictToGoogleFile(TestCase):
             'id': 'name',
             'parents': '[]'
         }
-        expected_google_file = GoogleFile(id='id', name='name', parents=[])
+        expected_google_file = GoogleFile(
+            id='id',
+            name='name',
+            parents=[],
+            mime_type='',
+            export_links={})
         sut = GoogleFileDictToGoogleFile()
 
         # when:


### PR DESCRIPTION
- Now credentials is the last arugment expected
  - e.g.: google-drive ls <path> <credentials-file>
- Now credentials could be a envvar
  - export CREDENTIALS=credentials.json && google-drive ls <path> <credentials-file>
- New command `get`. This will retrieve us file's metadata.
  - e.g.: google-drive get <ID>
- Extending models.GoogleFile.
  - Adding: mimeType and exportLinks fields.
  - Adding export types constants to get export type from a GoogleFile